### PR TITLE
adding link support because this particular ansible module does not s…

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,6 +17,7 @@
     image: "{{ item.docker_image_src|default(omit) }}"
     state: started
     restart_policy: always
+    links: "{{ item.docker_links|default(omit) }}"
     volumes: "{{ item.docker_volumes|default(omit) }}"
     expose: "{{ item.docker_expose_ports|default(omit) }}"
     ports: "{{ item.docker_port_mappings|default(omit) }}"


### PR DESCRIPTION
…upport network_mode like the docker_container_module in ansible 2.2